### PR TITLE
fix: resolve duplicate auth handler method and refactor registration …

### DIFF
--- a/backend/internal/api/auth.go
+++ b/backend/internal/api/auth.go
@@ -648,8 +648,8 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	})
 }
 
-// Register handles POST /api/v1/auth/register
-func (h *AuthHandler) Register(c *gin.Context) {
+// RegisterOrganization handles POST /api/v1/auth/register
+func (h *AuthHandler) RegisterOrganization(c *gin.Context) {
 	var req validation.RegistrationRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		logger.WithContext(c).Errorf("Invalid registration request: %v", err)

--- a/backend/internal/app/router.go
+++ b/backend/internal/app/router.go
@@ -28,7 +28,8 @@ func (a *App) RegisterRoutes() {
 			// Auth endpoints (no authentication required for registration and login)
 			auth := v1.Group("/auth")
 			{
-				auth.POST("/register", authHandler.Register)              // POST /api/v1/auth/register
+				auth.POST("/register", authHandler.RegisterOrganization)  // POST /api/v1/auth/register (organization registration)
+				auth.POST("/register-user", authHandler.Register)         // POST /api/v1/auth/register-user (user registration to existing org)
 				auth.POST("/login", authHandler.Login)                    // POST /api/v1/auth/login
 				auth.POST("/refresh", authHandler.RefreshToken)           // POST /api/v1/auth/refresh
 				auth.POST("/logout", middleware.AuthMiddleware(), authHandler.Logout) // POST /api/v1/auth/logout (requires auth)

--- a/backend/internal/tests/auth_test_utils.go
+++ b/backend/internal/tests/auth_test_utils.go
@@ -77,7 +77,8 @@ func SetupTestContext() (*TestContext, error) {
 	// Setup auth routes
 	authGroup := router.Group("/api/v1/auth")
 	{
-		authGroup.POST("/register", authHandler.Register)                                              // POST /api/v1/auth/register
+		authGroup.POST("/register", authHandler.RegisterOrganization)                               // POST /api/v1/auth/register (organization registration)
+		authGroup.POST("/register-user", authHandler.Register)                                      // POST /api/v1/auth/register-user (user registration to existing org)
 		authGroup.POST("/login", authHandler.Login)                                                    // POST /api/v1/auth/login
 		authGroup.POST("/refresh", authHandler.RefreshToken)                                           // POST /api/v1/auth/refresh
 		authGroup.POST("/logout", CreateTestAuthMiddleware(jwtService), authHandler.Logout)            // POST /api/v1/auth/logout (requires auth)

--- a/backend/internal/tests/integration/auth_test.go
+++ b/backend/internal/tests/integration/auth_test.go
@@ -121,7 +121,7 @@ func TestAuthHandler_Register(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			jsonBody, _ := json.Marshal(tc.request)
-			req := httptest.NewRequest("POST", "/api/v1/auth/register", bytes.NewBuffer(jsonBody))
+			req := httptest.NewRequest("POST", "/api/v1/auth/register-user", bytes.NewBuffer(jsonBody))
 			req.Header.Set("Content-Type", "application/json")
 
 			w := httptest.NewRecorder()


### PR DESCRIPTION
…endpoints

This commit resolves a critical compilation error caused by duplicate method declarations and implements a more robust authentication API structure.

Changes:
- **Method Disambiguation**: Renamed the second Register method to RegisterOrganization to eliminate the duplicate method declaration error
- **API Endpoint Separation**: Created distinct endpoints for different registration flows:
  -  - Organization registration (new orgs + owner user)
  -  - User registration to existing organizations
- **Router Configuration**: Updated both main and test routers to properly route requests to the correct handler methods
- **Test Coverage**: Fixed all failing integration tests by updating endpoint references and ensuring proper request routing

Technical Details:
- The original codebase had two Register methods handling different use cases
- Organization registration creates new orgs with owner users using RegistrationRequest
- User registration adds users to existing orgs using UserRegistrationRequest
- Both methods now have dedicated endpoints preventing routing conflicts
- All tests pass with full coverage maintained

This fix ensures the authentication system is robust, maintainable, and follows RESTful API design principles while supporting multi-tenant functionality.